### PR TITLE
Update ClosedCube_SHT31D.cpp

### DIFF
--- a/src/ClosedCube_SHT31D.cpp
+++ b/src/ClosedCube_SHT31D.cpp
@@ -52,7 +52,7 @@ SHT31D ClosedCube_SHT31D::periodicFetchData()
 	if (error == SHT3XD_NO_ERROR)
 		return readTemperatureAndHumidity();
 	else
-		returnError(error);
+		return returnError(error);
 }
 
 SHT31D_ErrorCode ClosedCube_SHT31D::periodicStop() {


### PR DESCRIPTION
In member function 'SHT31D ClosedCube_SHT31D::periodicFetchData()':
error: control reaches end of non-void function