### PR TITLE
Pr/11

### DIFF
--- a/src/ClosedCube_SHT31D.cpp
+++ b/src/ClosedCube_SHT31D.cpp
@@ -52,7 +52,7 @@ SHT31D ClosedCube_SHT31D::periodicFetchData()
 	if (error == SHT3XD_NO_ERROR)
 		return readTemperatureAndHumidity();
 	else
-		returnError(error);
+		return returnError(error);
 }
 
 SHT31D_ErrorCode ClosedCube_SHT31D::periodicStop() {

--- a/src/ClosedCube_SHT31D.cpp
+++ b/src/ClosedCube_SHT31D.cpp
@@ -27,7 +27,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 */
-#include <Wire.h>
 
 #include "ClosedCube_SHT31D.h"
 
@@ -384,7 +383,7 @@ SHT31D ClosedCube_SHT31D::readAlertData(SHT31D_Commands command)
 	result.rh = 0;
 
 	SHT31D_ErrorCode error;
-	
+
 	uint16_t buf;
 
 	error = writeCommand(command);

--- a/src/ClosedCube_SHT31D.h
+++ b/src/ClosedCube_SHT31D.h
@@ -32,6 +32,7 @@ THE SOFTWARE.
 #define CLOSEDCUBE_SHT31D
 
 #include <Arduino.h>
+#include <Wire.h>
 
 typedef enum {
 	SHT3XD_CMD_READ_SERIAL_NUMBER = 0x3780,
@@ -208,4 +209,4 @@ private:
 };
 
 
-#endif 
+#endif


### PR DESCRIPTION
changed the loading timing of the Wire library.
It compiles without including Wire in .ino.